### PR TITLE
feat: --restrict-to={glob} for "run" command

### DIFF
--- a/bin/lerna.js
+++ b/bin/lerna.js
@@ -22,6 +22,7 @@ var cli = meow([
   "  --canary, -c         Publish packages after every successful merge using the sha as part of the tag",
   "  --skip-git           Skip commiting, tagging, and pushing git changes (only affects publish)",
   "  --npm-tag [tagname]  Publish packages with the specified npm dist-tag",
+  "  --restrict-to [package glob] Restricts a command to run only packages matching the given glob (Works only in combination with the 'run' command).",
   "  --force-publish      Force publish for the specified packages (comma-seperated) or all packages using * (skips the git diff check for changed packages)"
 ], {
   alias: {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "lodash.find": "^4.3.0",
     "lodash.unionwith": "^4.2.0",
     "meow": "^3.7.0",
+    "minimatch": "^3.0.0",
     "mkdirp": "^0.5.1",
     "object-assign": "^4.0.1",
     "object-assign-sorted": "^1.0.0",

--- a/src/commands/RunCommand.js
+++ b/src/commands/RunCommand.js
@@ -1,6 +1,7 @@
 import NpmUtilities from "../NpmUtilities";
 import Command from "../Command";
 import async from "async";
+import minimatch from "minimatch";
 
 export default class RunCommand extends Command {
   initialize(callback) {
@@ -12,7 +13,20 @@ export default class RunCommand extends Command {
       return;
     }
 
-    this.packagesWithScript = this.packages
+    let packagesToRunCommandIn = this.packages;
+
+    if (this.flags.restrictTo && `${this.flags.restrictTo}`.length > 0) {
+        this.logger.info(`Restricting to packages that match '${this.flags.restrictTo}'`);
+        packagesToRunCommandIn = packagesToRunCommandIn
+            .filter(pkg => minimatch(pkg.name, this.flags.restrictTo));
+    }
+
+    if (!packagesToRunCommandIn.length) {
+      callback(new Error(`No packages found that match '${this.flags.restrictTo}'`));
+      return;
+    }
+
+    this.packagesWithScript = packagesToRunCommandIn
       .filter(pkg => pkg.scripts && pkg.scripts[this.script]);
 
     if (!this.packagesWithScript.length) {

--- a/test/RunCommand.js
+++ b/test/RunCommand.js
@@ -33,4 +33,43 @@ describe("RunCommand", () => {
 
     runCommand.runCommand(exitWithCode(0, done));
   });
+
+  it("should run a command for a single package when specified via --restrict-to", done => {
+    const runCommand = new RunCommand(["my-script"], {restrictTo: "package-1"});
+
+    runCommand.runValidations();
+    runCommand.runPreparations();
+
+    const ranInPackages = [];
+    stub(ChildProcessUtilities, "exec", (command, options, callback) => {
+        ranInPackages.push(options.cwd.substr(path.join(testDir, "packages/").length));
+        callback();
+    });
+
+    runCommand.runCommand(exitWithCode(0, () => {
+        assert.deepEqual(ranInPackages, ["package-1"]);
+        done();
+    }));
+  });
+
+  it("should run a command for packages matched by a glob when using --restrict-to", done => {
+    const runCommand = new RunCommand(["my-script"], {restrictTo: "package-*"});
+
+    runCommand.runValidations();
+    runCommand.runPreparations();
+
+    const ranInPackages = [];
+    stub(ChildProcessUtilities, "exec", (command, options, callback) => {
+        ranInPackages.push(options.cwd.substr(path.join(testDir, "packages/").length));
+        callback();
+    });
+
+    runCommand.runCommand(exitWithCode(0, () => {
+        assert.deepEqual(ranInPackages, [
+            "package-1",
+            "package-3"
+        ]);
+        done();
+    }));
+  });
 });


### PR DESCRIPTION
This adds a flag `--restrict-to` that takes a glob to restrict a command to be run to the packages matched by the glob.

implements #143
